### PR TITLE
Patch CI-Pipieline: Github-Package out of date

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
 
 
       - name: '📤 Archive Outputs'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: outputs
           path: output/*
@@ -103,7 +103,7 @@ jobs:
           ls -R docs/public
           
       - name: 'Upload Documentation Artifacts'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: 
           name: documentation
           path: |


### PR DESCRIPTION
Unfortunately, Github has retiered upload-artifact@v3. Therefore, we have to use the newer v4-Version. Apparently, this runs without any further need for change (see passed action/workflow). 